### PR TITLE
Update Eclipse configuration and project settings

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -6,7 +6,6 @@
 			<attribute name="gradle_used_by_scope" value="main,test"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="src/main/webapp"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
 	<classpathentry kind="output" path="bin/default"/>
 </classpath>

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,62 @@
-/.gradle/
-/target/
-/build/
-/bin/
+# Gradle
+.gradle/
+build/
+!gradle/wrapper/gradle-wrapper.jar
+
+# Maven
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+.mvn/wrapper/maven-wrapper.jar
+
+# Eclipse
+bin/
+.apt_generated/
+.factorypath
+
+# Allow Eclipse project files for easy import
+!.settings/
+!.classpath
+!.project
+
+# IntelliJ IDEA
+.idea/
+*.iml
+*.iws
+*.ipr
+out/
+
+# VS Code
+.vscode/
+
+# macOS
 .DS_Store
-src/.DS_Store
-src/main/.DS_Store
-src/main/java/.DS_Store
-src/main/java/com/.DS_Store
-src/main/java/com/ibm/.DS_Store
-src/main/java/com/ibm/cicsdev/.DS_Store
-src/main/java/com/ibm/cicsdev/springboot/.DS_Store
+
+# Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+
+# Log files
+*.log
+
+# Temporary files
+*.tmp
+*.bak
+*.swp
+*~
+
+# Package files
+*.jar
+*.war
+*.ear
+*.zip
+*.tar.gz
+*.rar
+

--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,3 @@
+eclipse.preferences.version=1
+encoding//src/test/java=UTF-8
+encoding/<project>=UTF-8

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,13 @@
+#
+#Tue Jun 16 15:59:47 BST 2026
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=17

--- a/.settings/org.eclipse.wst.common.component
+++ b/.settings/org.eclipse.wst.common.component
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project-modules id="moduleCoreId" project-version="1.5.0">
-	<wb-module deploy-name="com.ibm.cicsdev.springboot.jms">
+	<wb-module deploy-name="cics-java-liberty-springboot-jms">
 		<property name="context-root" value="cics-java-liberty-springboot-jms"/>
-		<wb-resource deploy-path="/WEB-INF/classes" source-path="src/main/java"/>
-		<wb-resource deploy-path="/" source-path="src/main/webapp"/>
 	</wb-module>
 </project-modules>

--- a/.settings/org.eclipse.wst.common.project.facet.core.xml
+++ b/.settings/org.eclipse.wst.common.project.facet.core.xml
@@ -3,5 +3,5 @@
 	<fixed facet="jst.java"/>
 	<fixed facet="jst.web"/>
 	<installed facet="jst.web" version="2.4"/>
-	<installed facet="jst.java" version="1.8"/>
+	<installed facet="jst.java" version="17"/>
 </faceted-project>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'com.ibm.cicsdev.springboot.jms'
+rootProject.name = 'cics-java-liberty-springboot-jms'


### PR DESCRIPTION
- Update .classpath to use JavaSE-17 (was JavaSE-1.8)
- Replace .gitignore with comprehensive version covering Maven, Gradle, Eclipse, IntelliJ, VS Code, macOS, and Windows
- Fix settings.gradle rootProject.name to match repository name
- Add .settings/org.eclipse.jdt.core.prefs with Java 17 compiler settings
- Update .settings/org.eclipse.wst.common.project.facet.core.xml to Java 17
- Update .settings/org.eclipse.wst.common.component deploy-name to match repository