### PR TITLE
Validation fixes: Eclipse config, CODEOWNERS, cicsbundle-eclipse, build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,7 +60,6 @@ jobs:
         with:
           java-version: ${{ matrix.jdk }}
           distribution: "semeru"
-          cache: maven
       - name: Build with Maven Wrapper
         run: ./mvnw --batch-mode --update-snapshots --file pom.xml -Djava.version=${{ matrix.jdk }} verify
 

--- a/.project
+++ b/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>com.ibm.cicsdev.springboot.jms</name>
+	<name>cics-java-liberty-springboot-jms</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,11 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
 org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error

--- a/.settings/org.eclipse.wst.common.component
+++ b/.settings/org.eclipse.wst.common.component
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project-modules id="moduleCoreId" project-version="1.5.0">
-	<wb-module deploy-name="cics-java-liberty-springboot-jms">
-		<property name="context-root" value="cics-java-liberty-springboot-jms"/>
-	</wb-module>
-</project-modules>

--- a/.settings/org.eclipse.wst.common.project.facet.core.xml
+++ b/.settings/org.eclipse.wst.common.project.facet.core.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<faceted-project>
-	<fixed facet="jst.java"/>
-	<fixed facet="jst.web"/>
-	<installed facet="jst.web" version="2.4"/>
-	<installed facet="jst.java" version="17"/>
-</faceted-project>

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# CODEOWNERS - Defines maintainers for this CICS sample
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# Last reviewed: 2026-07
+
+# For members of the team that maintains Java samples, see https://github.com/orgs/cicsdev/teams/cics-java-maintainers
+* @cicsdev/cics-java-maintainers

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,6 +1,0 @@
-# Maintainers
-
-- Ivan D. Hargreaves [@IvanHargreaves](https://github.com/IvanHargreaves)
-- Alex Brown [@AlexBrown](https://github.com/SoftlySplinter)
-
-*Last reviewed:* July 2026

--- a/README.md
+++ b/README.md
@@ -1,42 +1,80 @@
 # cics-java-liberty-springboot-jms
 [![Build](https://github.com/cicsdev/cics-java-liberty-springboot-jms/actions/workflows/build.yaml/badge.svg)](https://github.com/cicsdev/cics-java-liberty-springboot-jms/actions/workflows/build.yaml)
+[![License](https://img.shields.io/badge/License-EPL%202.0-green.svg)](https://www.eclipse.org/legal/epl-2.0/)
 
-This sample project demonstrates how to use the Spring Boot JMS template to integrate with CICS and use IBM MQ as the message provider. The sample is intended for deployment to a CICS Liberty JVM server. 
+## Overview
 
-Invoking the REST end-point of the application will write a message with the data you provide to MQ. A JMS listener endpoint receives the message from MQ and writes it to a CICS Temporary storage queue (TSQ). Reading from the JMS queue and writing to the CICS TSQ are performed within the same transaction using JTA via a Spring Boot container managed transaction, ensuring everything commits or rolls back as one recoverable unit.
+This sample project demonstrates how to use the Spring Boot JMS template to integrate with CICS and use IBM MQ as the message provider. The sample is intended for deployment to a CICS Liberty JVM server.
 
-For further details about the development of this sample refer to the IBM developer tutorial [Spring Boot Java applications for CICS, Part 5: JMS](https://developer.ibm.com/tutorials/spring-boot-java-applications-for-cics-part-5-jms/)
+Invoking the REST endpoint of the application will write a message with the data you provide to MQ. A JMS listener endpoint receives the message from MQ and writes it to a CICS Temporary Storage Queue (TSQ). Reading from the JMS queue and writing to the CICS TSQ are performed within the same transaction using JTA via a Spring Boot container managed transaction, ensuring everything commits or rolls back as one recoverable unit.
+
+**Key Features:**
+- **Spring JMS Integration**: Uses `spring-integration-jms` to send and receive JMS messages via IBM MQ
+- **Transactional Messaging**: JTA container-managed transaction spans both MQ read and CICS TSQ write
+- **RESTful Trigger**: REST endpoint triggers message send; JMS listener drives TSQ write
+- **Multi-Build Support**: Compatible with both Gradle and Maven
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Prerequisites](#prerequisites)
+3. [Reference](#reference)
+4. [Downloading](#downloading)
+5. [Check Dependencies](#check-dependencies)
+6. [Building the Sample](#building-the-sample)
+7. [Deploying to a CICS Liberty JVM server](#deploying-to-a-cics-liberty-jvm-server)
+8. [Running the Sample](#running-the-sample)
+9. [Troubleshooting](#troubleshooting)
+10. [License](#license)
+11. [Additional Resources](#additional-resources)
+12. [Contributing](#contributing)
 
 ## Prerequisites
 
-- CICS TS V6.1 or later
-- A configured Liberty JVM server
+- CICS TS V6.1 or later (required for Spring Boot 3.x and Jakarta EE 10 support)
+- A configured Liberty JVM server in CICS
 - Java SE 17 or later on the workstation
 - An Eclipse development environment on the workstation (optional)
 - Either Gradle or Apache Maven on the workstation (optional if using Wrappers)
 - IBM MQ V8.0 or later on z/OS
-- IBM MQ Resource Adapter for the WebSphere Application Server Liberty available from https://www.ibm.com/support/pages/node/489235
+- IBM MQ Resource Adapter for WebSphere Application Server Liberty, available from https://www.ibm.com/support/pages/node/489235
+
+## Reference
+
+For more information about the development of this sample, see [Spring Boot Java applications for CICS, Part 5: JMS](https://developer.ibm.com/tutorials/spring-boot-java-applications-for-cics-part-5-jms/).
 
 ## Downloading
 
-- Clone the repository using your IDEs support, such as the Eclipse Git plugin
-- **or**, download the sample as a [ZIP](https://github.com/cicsdev/cics-java-liberty-springboot-jms/archive/main.zip) and unzip onto the workstation
+**If using Eclipse:** the simplest approach is to clone the repository using the Eclipse Git plugin (EGit) perspective.
 
->*Tip: Eclipse Git provides an 'Import existing Projects' check-box when cloning a repository.*
+**If using the command line:**
+```shell
+git clone https://github.com/cicsdev/cics-java-liberty-springboot-jms
+```
+Alternatively, download the sample as a [ZIP](https://github.com/cicsdev/cics-java-liberty-springboot-jms/archive/main.zip) and unzip onto the workstation.
+
+**If importing into Eclipse:**
+1. In the **Git Repositories** view, right-click the repository → **Import as Project** (imports the root project)
+   *(if you cloned from the command line, use **File → Import → Existing Projects into Workspace** instead, browse to the cloned directory, select all projects, and skip to step 6)*
+2. Switch to the **Java EE** perspective
+3. In the **Project Explorer**, right-click the `cics-java-liberty-springboot-jms-app` folder → **Import as Project**
+4. Right-click the `cics-java-liberty-springboot-jms-cicsbundle` folder → **Import as Project**
+5. Right-click the `cics-java-liberty-springboot-jms-cicsbundle-eclipse` folder → **Import as Project**
+6. **Required:** Right-click the root project → **Gradle → Refresh Gradle Project** or **Maven → Update Project...** — this resolves Spring Boot and CICS dependencies into the project classpath. Without this step, the WTP export will produce an incomplete WAR missing `WEB-INF/lib`.
 
 ### Check dependencies
- 
+
 Before building this sample, you should verify that the correct CICS TS bill of materials (BOM) is specified for your target release of CICS. The BOM specifies a consistent set of artifacts, and adds information about their scope. In the example below the version specified is compatible with CICS TS V6.1 with JCICS APAR PH63856, or newer. That is, the Java byte codes built by compiling against this version of JCICS will be compatible with later CICS TS versions and subsequent JCICS APARs.
 
 You can browse the published versions of the CICS BOM at [Maven Central.](https://mvnrepository.com/artifact/com.ibm.cics/com.ibm.cics.ts.bom)
- 
-Gradle (cics-java-liberty-springboot-jms-app/build.gradle):
+
+Gradle (build.gradle):
 
 `compileOnly enforcedPlatform("com.ibm.cics:com.ibm.cics.ts.bom:6.1-20250812133513-PH63856")`
 
-Maven (cics-java-liberty-springboot-jms-app/pom.xml):
+Maven (POM.xml):
 
-``` xml
+```xml
 <dependencyManagement>
   <dependencies>
     <dependency>
@@ -50,27 +88,19 @@ Maven (cics-java-liberty-springboot-jms-app/pom.xml):
 </dependencyManagement>
 ```
 
-## Updating
-
-The JMSMessageReceiver.java class assumes an MQ destination of `SPRING.QUEUE`. If that value does not meet your enterprise naming standards, this can be updated by modifying the static variable `MDP_QUEUE`.
-
-## Building
+## Building the Sample
 
 You can build the sample using an IDE of your choice, or you can build it from the command line. For both approaches, using the supplied Gradle or Maven wrapper is the recommended way to get a consistent version of build tooling.
 
 On the command line, you simply swap the Gradle or Maven command for the wrapper equivalent, `gradlew` or `mvnw` respectively.
-  
+
 For an IDE, taking Eclipse as an example, the plug-ins for Gradle *buildship* and Maven *m2e* will integrate with the "Run As..." capability, allowing you to specify whether you want to build the project with a Wrapper, or a specific version of your chosen build tool.
 
-The required build-tasks are typically `clean build` for Gradle and `clean verify` for Maven. Once run, Gradle will generate a WAR file in the `cics-java-liberty-springboot-jms-app/build/libs` directory, while Maven will generate it in the `cics-java-liberty-springboot-jms-app/target` directory.
+The required build-tasks are `clean build` for Gradle and `clean verify` for Maven. Once run, Gradle will generate a WAR file in the `cics-java-liberty-springboot-jms-app/build/libs` directory, while Maven will generate it in the `cics-java-liberty-springboot-jms-app/target` directory.
 
 **Note:** When building a WAR file for deployment to Liberty it is good practice to exclude Tomcat from the final runtime artifact. We demonstrate this in the pom.xml with the *provided* scope, and in build.gradle with the *providedRuntime()* dependency.
 
-**Note:** If you import the project to your IDE, you might experience local project compile errors. To resolve these errors you should run a tooling refresh on that project. For example, in Eclipse: right-click on "Project", select "Gradle -> Refresh Gradle Project", **or** right-click on "Project", select "Maven -> Update Project...".
-
->Tip: *In Eclipse, Gradle (buildship) is able to fully refresh and resolve the local classpath even if the project was previously updated by Maven. However, Maven (m2e) does not currently reciprocate that capability. If you previously refreshed the project with Gradle, you'll need to manually remove the 'Project Dependencies' entry on the Java build-path of your Project Properties to avoid duplication errors when performing a Maven Project Update.*
-
-#### Gradle Wrapper (command line)
+### Gradle Wrapper (command line)
 
 Run the following in a local command prompt:
 
@@ -79,6 +109,7 @@ On Linux or Mac:
 ```shell
 ./gradlew clean build
 ```
+
 On Windows:
 
 ```shell
@@ -87,7 +118,9 @@ gradlew.bat clean build
 
 This creates a WAR file inside the `cics-java-liberty-springboot-jms-app/build/libs` directory.
 
-#### Maven Wrapper (command line)
+> **Note:** In Eclipse, the `build` directory may be hidden by default. To view it: **Package Explorer → ⋮ → Filters and Customization → uncheck "Gradle build folder"**. For Maven, the `target` directory is visible by default.
+
+### Maven Wrapper (command line)
 
 Run the following in a local command prompt:
 
@@ -105,80 +138,151 @@ mvnw.cmd clean verify
 
 This creates a WAR file inside the `cics-java-liberty-springboot-jms-app/target` directory.
 
-## Deploying
+## Deploying to a CICS Liberty JVM server
 
-### IBM MQ
+### IBM MQ configuration
 
-You will need to configure
-- An MQ queue manager listening on a accessible TCP/IP port.
-- A queue named SPRING.QUEUE
+Before deploying, configure the following on your MQ queue manager:
 
-> Note: Queues should be defined as shareable to allow usage in the multi-threaded environment in Liberty. 
-In addition it is advisable to set the `BackoutThreshold` attribute on the queue, to prevent the MDP being constantly re-driven if the MDP fails during the processing of the message.
+- An MQ queue manager listening on an accessible TCP/IP port
+- A queue named `SPRING.QUEUE`
 
-### CICS Liberty
+> **Note:** Queues should be defined as shareable to allow usage in the multi-threaded Liberty environment. It is also advisable to set the `BackoutThreshold` attribute on the queue to prevent the MDP being constantly re-driven if message processing fails.
 
-- Ensure you have the following features in `server.xml`:
-    - `servlet-6.0` for Jakarta EE 10.
-    - `concurrent-3.0`.
-    - `messaging-3.1`.
-    - `wmqJmsClient-2.0`.
-    - `jndi-1.0`.
-    - `cicsts:security-1.0` if CICS security is enabled.
+> **Note:** The queue name `SPRING.QUEUE` is defined as the static variable `MDP_QUEUE` in `JMSMessageReceiver.java`. If the name does not meet your enterprise naming standards, update that variable before building.
 
->**Note:** This sample uses Spring Boot 3.x which requires Jakarta EE 10 and Java 17 or later
+### CICS Liberty configuration
 
-- Add the JMS MQ Connection Factory configuration to `server.xml`
+Ensure you have the following features defined in your Liberty `server.xml`:
 
-  Here's an example of configuration needed in `server.xml`. Substitute the *channel*, *hostname*, *port* and *queueManager* values to your installation values, and fill in the MQ rar location value with the location on zFS to which you downloaded the rar. Download instructions can be found linked from the prerequisites section earlier: 
+- `servlet-6.0` (required for Spring Boot 3.x and Jakarta EE 10)
+- `concurrent-3.0`
+- `messaging-3.1`
+- `wmqJmsClient-2.0`
+- `jndi-1.0`
 
-    ``` XML
-    <!-- JMS MQ Connection Factory -->
-    <jmsConnectionFactory id="jms/cf" jndiName="jms/cf">
-        <properties.wmqJms channel="yourChannel" hostname="yourHost" port="yourPort" 
-        queueManager="yourQueueManager" transportType="CLIENT"/>
-        <connectionManager maxPoolSize="10" minPoolSize="0"/>
-    </jmsConnectionFactory>
-    <variable name="wmqJmsClient.rar.location" value="/wmq.jmsra-9.0.4.0.rar"/>
-    ```
+Also add the JMS MQ Connection Factory configuration to `server.xml`. Substitute the *channel*, *hostname*, *port*, and *queueManager* values for your installation, and set the MQ RAR location to the path on zFS where you downloaded the resource adapter:
 
-The value of 10 on `maxPoolSize` is used as an example only. Set `maxPoolSize` to the maximum number of concurrent users of the connection factory.
- 
-- Deployment option 1:
-    - Build the CICS bundle using `./gradlew clean build` or `./mvnw clean verify`. This generates a ZIP file in the `cics-java-liberty-springboot-jms-cicsbundle/build/distributions` or `cics-java-liberty-springboot-jms-cicsbundle/target` directory. Upload the ZIP to zFS and deploy it as a CICS bundle.
+```xml
+<jmsConnectionFactory id="jms/cf" jndiName="jms/cf">
+    <properties.wmqJms channel="yourChannel" hostname="yourHost" port="yourPort"
+    queueManager="yourQueueManager" transportType="CLIENT"/>
+    <connectionManager maxPoolSize="10" minPoolSize="0"/>
+</jmsConnectionFactory>
+<variable name="wmqJmsClient.rar.location" value="/wmq.jmsra-9.0.4.0.rar"/>
+```
 
-- Deployment option 2:
-    - Copy and paste the built WAR from your *cics-java-liberty-springboot-jms-app/target* or *cics-java-liberty-springboot-jms-app/build/libs* directory into an Eclipse CICS bundle project and create a new WAR bundlepart that references the WAR file. Then deploy the CICS bundle project from CICS Explorer using the **Export Bundle Project to z/OS UNIX File System** wizard.
+> **Note:** The value of `10` on `maxPoolSize` is an example only. Set it to the maximum number of concurrent users of the connection factory.
 
-- Deployment option 3:
-    - Manually upload the WAR file to zFS and add an `<application>` element to the Liberty server.xml to define the web application with access to all authenticated users. For example the following application element can be used to install a WAR, and grant access to all authenticated users if security is enabled.
+A template `server.xml` is provided [here](./etc/config/liberty/server.xml).
 
-    ``` XML
-    <application id="cics-java-liberty-springboot-jms-app-1.0.0"
-        location="${server.config.dir}/springapps/cics-java-liberty-springboot-jms-app-1.0.0.war"
-        name="cics-java-liberty-springboot-jms-app-1.0.0" type="war">
-        <application-bnd>
-            <security-role name="cicsAllAuthenticated">
-                <special-subject type="ALL_AUTHENTICATED_USERS"/>
-            </security-role>
-        </application-bnd>
-    </application>
-    ```
+### CICS Bundle Plugin Deployment (Gradle/Maven)
 
-## Trying out the sample
+This method uses the CICS bundle generated during the build process.
+
+**Configure your JVM server name:**
+
+Gradle (`cics-java-liberty-springboot-jms-cicsbundle/build.gradle`):
+```gradle
+cics.jvmserver = 'YOUR_JVMSERVER_NAME'  // e.g., 'DFHWLP'
+```
+
+Maven (`cics-java-liberty-springboot-jms-cicsbundle/pom.xml`):
+```xml
+<cics.jvmserver>YOUR_JVMSERVER_NAME</cics.jvmserver>  <!-- e.g., DFHWLP -->
+```
+
+**Deploy the bundle:**
+
+1. Upload the CICS bundle ZIP file to zFS:
+   - Gradle: `cics-java-liberty-springboot-jms-cicsbundle/build/distributions/cics-java-liberty-springboot-jms-cicsbundle-1.0.0.zip`
+   - Maven: `cics-java-liberty-springboot-jms-cicsbundle/target/cics-java-liberty-springboot-jms-cicsbundle-1.0.0.zip`
+
+2. Unzip the bundle on zFS
+
+3. Create a CICS BUNDLE resource definition:
+   ```
+   CEDA DEFINE BUNDLE(JMSSAMP) GROUP(MYGROUP) BUNDLEDIR(/path/to/bundle)
+   ```
+
+4. Install the bundle:
+   ```
+   CEDA INSTALL BUNDLE(JMSSAMP) GROUP(MYGROUP)
+   ```
+
+---
+
+### CICS Explorer SDK Deployment
+
+This repository includes a pre-configured Eclipse CICS bundle project `cics-java-liberty-springboot-jms-cicsbundle-eclipse` that can be used directly with CICS Explorer SDK.
+
+1. Right-click the `cics-java-liberty-springboot-jms-cicsbundle-eclipse` project → **Export Bundle Project to z/OS UNIX File System** and follow the wizard
+
+> **Note**: The bundle project is pre-configured so that the Eclipse WTP export automatically packages the application WAR with all dependencies. This relies on the `-app` project being open in the same Eclipse workspace. If you have not yet imported the project, follow steps 3 and 6 of the [Importing into Eclipse](#downloading) instructions first.
+
+---
+
+### Direct Liberty Application Deployment
+
+1. Manually upload the WAR file to zFS
+2. Add an `<application>` element to the Liberty server.xml to define the web application with access to all authenticated users. For example:
+
+```xml
+<application id="cics-java-liberty-springboot-jms"
+    location="${server.config.dir}/springapps/cics-java-liberty-springboot-jms.war"
+    name="cics-java-liberty-springboot-jms" type="war">
+    <application-bnd>
+        <security-role name="cicsAllAuthenticated">
+            <special-subject type="ALL_AUTHENTICATED_USERS"/>
+        </security-role>
+    </application-bnd>
+</application>
+```
+
+---
+
+## Running the Sample
 
 1. Ensure the web application started successfully in Liberty by checking for msg `CWWKT0016I` in the Liberty messages.log:
+   ```
+   CWWKT0016I: Web application available (default_host): http://myzos.mycompany.com:httpPort/cics-java-liberty-springboot-jms
+   SRVE0292I: Servlet Message - [cics-java-liberty-springboot-jms]:.Initializing Spring embedded WebApplicationContext
+   ```
 
-    - `A CWWKT0016I: Web application available (default_host): http://myzos.mycompany.com:httpPort/cics-java-liberty-springboot-jms-app-1.0.0`
-    - `I SRVE0292I: Servlet Message - [cics-java-liberty-springboot-jms-app-1.0.0]:.Initializing Spring embedded WebApplicationContext`
+2. Send a message to MQ by invoking the REST endpoint with your TSQ name and message data:
+   ```
+   http://myzos.mycompany.com:httpPort/cics-java-liberty-springboot-jms/send/SPRING.QUEUE?data=I LOVE CICS
+   ```
 
-2. Copy the context root from message CWWKT0016I along with the REST service suffix `send/SPRING.QUEUE?data=I LOVE CICS` into you web browser. e.g. `http://myzos.mycompany.com:httpPort/cics-java-liberty-springboot-jms-app-1.0.0/send/SPRING.QUEUE?data=I LOVE CICS`.
+3. Check if the specified TSQ has the information you expected by executing the CICS 3270 command `CEBR SPRINGQ`. You should see `I LOVE CICS` in TSQ SPRINGQ.
 
-3. Check if the specified TSQ has the information you expected by executing the CICS 3270 command `CEBR SPRINGQ`. For this example, you should just see one `I LOVE CICS` in TSQ SPRINGQ. 
+4. Check that the Spring MDP Bean was driven by viewing the messages in the Liberty messages.log.
 
-4. Check that the Spring MDP Bean has been driven by viewing the messages in the Liberty messages.log
+---
 
+## Troubleshooting
+
+**Issue: Application fails to start**
+- Check Liberty messages.log for errors
+- Verify all required features are enabled in `server.xml` (see [CICS Liberty configuration](#cics-liberty-configuration))
+- Confirm CICS TS version supports Spring Boot 3.x (V6.1+)
+
+**Issue: Messages not appearing in TSQ**
+- Verify the MQ queue manager is accessible and `SPRING.QUEUE` exists and is defined as shareable
+- Check the MQ connection factory configuration in `server.xml` matches your installation
+- Review Liberty messages.log for JMS connection errors
 
 ## License
 
-This project is licensed under [Eclipse Public License - v 2.0](LICENSE). 
+This project is licensed under [Eclipse Public License - v 2.0](LICENSE).
+
+## Additional Resources
+
+- [CICS TS Documentation](https://www.ibm.com/docs/en/cics-ts)
+- [Spring Boot Java applications for CICS, Part 5: JMS](https://developer.ibm.com/tutorials/spring-boot-java-applications-for-cics-part-5-jms/)
+- [Spring Integration JMS Documentation](https://docs.spring.io/spring-integration/reference/jms.html)
+- [IBM MQ Resource Adapter download](https://www.ibm.com/support/pages/node/489235)
+
+## Contributing
+
+This sample is maintained by IBM CICS development. We welcome bug reports and feature requests via GitHub Issues. Contributions are welcome and reviewed on a case-by-case basis — please read the [contributing guidelines](https://github.com/cicsdev/.github/blob/main/CONTRIBUTING.md) before opening a pull request. For CICS product questions, contact IBM Support.

--- a/cics-java-liberty-springboot-jms-app/.classpath
+++ b/cics-java-liberty-springboot-jms-app/.classpath
@@ -1,21 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry kind="src" path="src/main/java"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
-	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.web.container"/>
 	<classpathentry kind="con" path="com.ibm.cics.explorer.sdk.web.LIBERTY_LIBRARIES/L./V.61/JE.JEE_V10_R0">
 		<attributes>
 			<attribute name="owner.project.facets" value="jst.web"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.web.container"/>
 	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer">
 		<attributes>
 			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path=".apt_generated">
-		<attributes>
-			<attribute name="optional" value="true"/>
-		</attributes>
-	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER"/>
 	<classpathentry kind="output" path="bin/default"/>
 </classpath>

--- a/cics-java-liberty-springboot-jms-app/.settings/org.eclipse.jdt.core.prefs
+++ b/cics-java-liberty-springboot-jms-app/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,11 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
 org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error

--- a/cics-java-liberty-springboot-jms-app/.settings/org.eclipse.wst.common.project.facet.core.xml
+++ b/cics-java-liberty-springboot-jms-app/.settings/org.eclipse.wst.common.project.facet.core.xml
@@ -2,6 +2,6 @@
 <faceted-project>
 	<fixed facet="jst.java"/>
 	<fixed facet="jst.web"/>
-	<installed facet="jst.web" version="2.4"/>
+	<installed facet="jst.web" version="6.0"/>
 	<installed facet="jst.java" version="17"/>
 </faceted-project>

--- a/cics-java-liberty-springboot-jms-app/.settings/org.eclipse.wst.validation.prefs
+++ b/cics-java-liberty-springboot-jms-app/.settings/org.eclipse.wst.validation.prefs
@@ -1,0 +1,10 @@
+DELEGATES_PREFERENCE=delegateValidatorList
+USER_BUILD_PREFERENCE=enabledBuildValidatorList
+USER_MANUAL_PREFERENCE=enabledManualValidatorList
+USER_PREFERENCE=overrideGlobalPreferencestruedisableAllValidationfalseversion1.3.100.v202407180051
+disabled=06target
+eclipse.preferences.version=1
+override=true
+suspend=false
+vals/org.eclipse.jst.j2ee.internal.classpathdep.ClasspathDependencyValidator/global=FF
+vf.version=3

--- a/cics-java-liberty-springboot-jms-app/build.gradle
+++ b/cics-java-liberty-springboot-jms-app/build.gradle
@@ -40,6 +40,17 @@ eclipse
     {
         downloadJavadoc = true
     }
+    wtp
+    {
+        facet
+        {
+            facet name: 'jst.web', version: '6.0'
+        }
+        component
+        {
+            contextPath = 'cics-java-liberty-springboot-jms'
+        }
+    }
 }
 
 repositories 

--- a/cics-java-liberty-springboot-jms-app/src/main/webapp/WEB-INF/ibm-web-ext.xml
+++ b/cics-java-liberty-springboot-jms-app/src/main/webapp/WEB-INF/ibm-web-ext.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-ext
+    xmlns="http://websphere.ibm.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-ext_1_0.xsd"
+    version="1.0">
+    <context-root uri="cics-java-liberty-springboot-jms"/>
+</web-ext>

--- a/cics-java-liberty-springboot-jms-cicsbundle-eclipse/.project
+++ b/cics-java-liberty-springboot-jms-cicsbundle-eclipse/.project
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>cics-java-liberty-springboot-jms-cicsbundle-eclipse</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>com.ibm.cics.bundle.ui.bundlebuilder</name>
+			<arguments>
+				<dictionary>
+					<key>bundleID</key>
+					<value>cics-java-liberty-springboot-jms-bundle</value>
+				</dictionary>
+				<dictionary>
+					<key>majorVersion</key>
+					<value></value>
+				</dictionary>
+				<dictionary>
+					<key>microVersion</key>
+					<value></value>
+				</dictionary>
+				<dictionary>
+					<key>minorVersion</key>
+					<value></value>
+				</dictionary>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>com.ibm.cics.bundle.ui.bundlenature</nature>
+	</natures>
+</projectDescription>

--- a/cics-java-liberty-springboot-jms-cicsbundle-eclipse/.settings/org.eclipse.core.resources.prefs
+++ b/cics-java-liberty-springboot-jms-cicsbundle-eclipse/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/cics-java-liberty-springboot-jms-cicsbundle-eclipse/META-INF/cics.xml
+++ b/cics-java-liberty-springboot-jms-cicsbundle-eclipse/META-INF/cics.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<manifest xmlns="http://www.ibm.com/xmlns/prod/cics/bundle" id="cics-java-liberty-springboot-jms-bundle" bundleMajorVer="1" bundleMinorVer="0" bundleMicroVer="0" bundleVersion="1" bundleRelease="0">
+    <meta_directives>
+        <timestamp>2026-01-01T00:00:00.000Z</timestamp>
+    </meta_directives>
+    <define name="cics-java-liberty-springboot-jms-app" type="http://www.ibm.com/xmlns/prod/cics/bundle/WARBUNDLE" path="cics-java-liberty-springboot-jms.warbundle"/>
+</manifest>

--- a/cics-java-liberty-springboot-jms-cicsbundle-eclipse/cics-java-liberty-springboot-jms.warbundle
+++ b/cics-java-liberty-springboot-jms-cicsbundle-eclipse/cics-java-liberty-springboot-jms.warbundle
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<warbundle symbolicname="cics-java-liberty-springboot-jms-app" jvmserver="DFHWLP"/>

--- a/etc/config/liberty/server.xml
+++ b/etc/config/liberty/server.xml
@@ -1,29 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<server description="CICS Liberty JVM server template configuration">
+<server description="Liberty server for CICS Spring Boot JMS sample">
 
-    <!-- Enable features -->
     <featureManager>
-        <feature>cicsts:core-1.0</feature>
+        <!-- Required for Spring Boot 3.x and Jakarta EE 10 -->
         <feature>servlet-6.0</feature>
+        <!-- Required for Spring @Async with CICS-enabled threads -->
         <feature>concurrent-3.0</feature>
+        <!-- JMS messaging support -->
         <feature>messaging-3.1</feature>
+        <!-- IBM MQ JMS resource adapter -->
         <feature>wmqJmsClient-2.0</feature>
+        <!-- JNDI lookup for JMS connection factory -->
         <feature>jndi-1.0</feature>
     </featureManager>
 
-    <!-- Default HTTP End Point -->
-    <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="9080" />
-
-    <!-- Reduce z/FS overheads by reducing config and app polling -->
-    <config monitorInterval="5s" updateTrigger="polled" />
-    <applicationMonitor updateTrigger="disabled" dropins="dropins"
-        dropinsEnabled="false" pollingRate="5s" />
-
-    <!-- MQ JMS resource adpater location -->
-    <variable name="wmqJmsClient.rar.location"
-        value="/usr/lpp/mqm/V9R0M0/java/lib/jca/wmq.jmsra.rar" />
-
-    <!-- JMS MQ Connection Factory -->
+    <!-- MQ JMS Connection Factory — substitute your values -->
     <jmsConnectionFactory id="jms/cf" jndiName="jms/cf">
         <properties.wmqJms
             transportType="CLIENT"
@@ -33,4 +24,9 @@
             queueManager="QM1" />
         <connectionManager maxPoolSize="10" minPoolSize="0" />
     </jmsConnectionFactory>
+
+    <!-- MQ JMS resource adapter location -->
+    <variable name="wmqJmsClient.rar.location"
+        value="/usr/lpp/mqm/V9R0M0/java/lib/jca/wmq.jmsra.rar" />
+
 </server>

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,6 @@
   <properties>
     <java.version>17</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>${java.version}</maven.compiler.target>
-    <maven.compiler.source>${java.version}</maven.compiler.source>
     <cics.jvmserver>DFHWLP</cics.jvmserver>
   </properties>
   


### PR DESCRIPTION

- Eclipse: fix root .project name; canonicalise root and -app jdt.core.prefs; remove root WTP facet files (Issue 10); fix -app/.classpath (src entry, Maven container bare, CICS Liberty Libraries, reorder); fix WTP facet jst.web 2.4 -> 6.0; add org.eclipse.wst.validation.prefs (suppress ClasspathDependencyValidator); add eclipse.wtp block to build.gradle (Issue 13); create cicsbundle-eclipse project (.project, META-INF/cics.xml, .warbundle, org.eclipse.core.resources.prefs)
- Add ibm-web-ext.xml with correct context-root
- MAINTAINERS.md -> CODEOWNERS
- pom.xml: remove deprecated maven.compiler.source/target properties
- build.yaml: remove cache:maven from build-mvnw
- server.xml: remove cicsts:core-1.0, httpEndpoint, monitoring config
- README: standard structure — strengthen step 6 (Required, WEB-INF/lib consequence), fix CICS Explorer SDK note step reference (5 -> 3 and 6), rewrite Downloading section (EGit/CLI fork), remove recommended label from Bundle Plugin section, remove resolved red markers troubleshooting entry