### PR TITLE
Validation fixes: Eclipse config, CODEOWNERS, cicsbundle-eclipse

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Invoking the REST endpoint of the application will write a message with the data
 - Java SE 17 or later on the workstation
 - An Eclipse development environment on the workstation (optional)
 - Either Gradle or Apache Maven on the workstation (optional if using Wrappers)
-- IBM MQ V8.0 or later on z/OS
-- IBM MQ Resource Adapter for WebSphere Application Server Liberty, available from https://www.ibm.com/support/pages/node/489235
+- IBM MQ V9.3 or later on z/OS (V9.3+ required for the Jakarta JMS resource adapter)
+- IBM MQ Jakarta JMS Resource Adapter (`wmq.jakarta.jmsra.rar`), available from https://www.ibm.com/support/pages/obtaining-ibm-mq-resource-adapter-websphere-application-server-liberty-profile
 
 ## Reference
 
@@ -157,8 +157,7 @@ Ensure you have the following features defined in your Liberty `server.xml`:
 
 - `servlet-6.0` (required for Spring Boot 3.x and Jakarta EE 10)
 - `concurrent-3.0`
-- `messaging-3.1`
-- `wmqJmsClient-2.0`
+- `wmqMessagingClient-3.0` (IBM MQ Jakarta JMS client — requires MQ 9.3+ with the Jakarta RAR)
 - `jndi-1.0`
 
 Also add the JMS MQ Connection Factory configuration to `server.xml`. Substitute the *channel*, *hostname*, *port*, and *queueManager* values for your installation, and set the MQ RAR location to the path on zFS where you downloaded the resource adapter:
@@ -169,7 +168,7 @@ Also add the JMS MQ Connection Factory configuration to `server.xml`. Substitute
     queueManager="yourQueueManager" transportType="CLIENT"/>
     <connectionManager maxPoolSize="10" minPoolSize="0"/>
 </jmsConnectionFactory>
-<variable name="wmqJmsClient.rar.location" value="/wmq.jmsra-9.0.4.0.rar"/>
+<variable name="wmqJmsClient.rar.location" value="/usr/lpp/mqm/V9R4M4/java/lib/jca/wmq.jakarta.jmsra.rar"/>
 ```
 
 > **Note:** The value of `10` on `maxPoolSize` is an example only. Set it to the maximum number of concurrent users of the connection factory.
@@ -281,7 +280,7 @@ This project is licensed under [Eclipse Public License - v 2.0](LICENSE).
 - [CICS TS Documentation](https://www.ibm.com/docs/en/cics-ts)
 - [Spring Boot Java applications for CICS, Part 5: JMS](https://developer.ibm.com/tutorials/spring-boot-java-applications-for-cics-part-5-jms/)
 - [Spring Integration JMS Documentation](https://docs.spring.io/spring-integration/reference/jms.html)
-- [IBM MQ Resource Adapter download](https://www.ibm.com/support/pages/node/489235)
+- [IBM MQ Jakarta JMS Resource Adapter](https://www.ibm.com/support/pages/obtaining-ibm-mq-resource-adapter-websphere-application-server-liberty-profile)
 
 ## Contributing
 

--- a/cics-java-liberty-springboot-jms-app/src/main/java/com/ibm/cicsdev/springboot/jms/JMSMessageSendController.java
+++ b/cics-java-liberty-springboot-jms-app/src/main/java/com/ibm/cicsdev/springboot/jms/JMSMessageSendController.java
@@ -10,12 +10,12 @@ import java.util.Date;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jms.JmsException;
 import org.springframework.jms.core.JmsTemplate;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import org.springframework.web.bind.annotation.PathVariable;
 
 
 /**
@@ -57,8 +57,10 @@ public class JMSMessageSendController
      * @param jmsq, path variable for JMS queue name
      * @return, the JMS message to send to the MQ destination
      */
-    @RequestMapping("/send/{jmsq}")
-    public String send(@RequestParam(value = "data") String inputStr, @PathVariable String jmsq) 
+    @RequestMapping(value = "/send/{jmsq}", produces = MediaType.TEXT_PLAIN_VALUE)
+    public String send(
+    		@RequestParam("data") String inputStr,
+    		@PathVariable("jmsq") String jmsq)
     {       
         try 
         {

--- a/etc/config/liberty/server.xml
+++ b/etc/config/liberty/server.xml
@@ -6,10 +6,8 @@
         <feature>servlet-6.0</feature>
         <!-- Required for Spring @Async with CICS-enabled threads -->
         <feature>concurrent-3.0</feature>
-        <!-- JMS messaging support -->
-        <feature>messaging-3.1</feature>
-        <!-- IBM MQ JMS resource adapter -->
-        <feature>wmqJmsClient-2.0</feature>
+        <!-- IBM MQ Jakarta JMS client (requires MQ 9.3+ with Jakarta RAR) -->
+        <feature>wmqMessagingClient-3.0</feature>
         <!-- JNDI lookup for JMS connection factory -->
         <feature>jndi-1.0</feature>
     </featureManager>
@@ -25,8 +23,8 @@
         <connectionManager maxPoolSize="10" minPoolSize="0" />
     </jmsConnectionFactory>
 
-    <!-- MQ JMS resource adapter location -->
+    <!-- IBM MQ Jakarta JMS resource adapter location (MQ 9.4.4) -->
     <variable name="wmqJmsClient.rar.location"
-        value="/usr/lpp/mqm/V9R0M0/java/lib/jca/wmq.jmsra.rar" />
+        value="/usr/lpp/mqm/V9R4M4/java/lib/jca/wmq.jakarta.jmsra.rar" />
 
 </server>


### PR DESCRIPTION
README

- Eclipse: fix root .project name; canonicalise root and -app jdt.core.prefs; remove root WTP facet files (Issue 10); fix -app/.classpath (src entry, Maven container bare, CICS Liberty Libraries, reorder); fix WTP facet jst.web 2.4 -> 6.0; add org.eclipse.wst.validation.prefs (Issue 11a); add eclipse.wtp block to build.gradle (Issue 13); create cicsbundle-eclipse project (.project, META-INF/cics.xml, .warbundle, org.eclipse.core.resources.prefs)
- Add ibm-web-ext.xml with correct context-root
- MAINTAINERS.md -> CODEOWNERS
- pom.xml: remove deprecated maven.compiler.source/target properties
- build.yaml: remove cache:maven from build-mvnw
- server.xml: remove cicsts:core-1.0, httpEndpoint, monitoring config; fix MQ feature messaging-3.1 + wmqJmsClient-2.0 -> wmqMessagingClient-3.0; update RAR path to wmq.jakarta.jmsra.rar (MQ 9.4.4)
- README: standard structure; fix MQ prerequisites (V9.3+, Jakarta RAR); fix feature list (wmqMessagingClient-3.0); fix RAR path example; update MQ Resource Adapter download link; strengthen step 6 import instruction; fix CICS Explorer SDK note step reference; rewrite Downloading section; remove recommended label from Bundle Plugin section; remove resolved red markers troubleshooting entry